### PR TITLE
Bump minimum python version to 3.11

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ["3.11", "3.12"]
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: windows-latest
+            python-version: "3.12"
         test-subset:
           - |
             tests/

--- a/conda_envs/environment.yml
+++ b/conda_envs/environment.yml
@@ -22,8 +22,8 @@ dependencies:
   - preliz
   - ipython
   - nutpie
+  - sympytensor
+  - pymc-extras
 
   - pip:
-      - sympytensor
       - flowjax
-      - git+https://github.com/pymc-devs/pymc-extras.git

--- a/conda_envs/environment_dev.yml
+++ b/conda_envs/environment_dev.yml
@@ -25,10 +25,11 @@ dependencies:
   - ipython
   - notebook<7
   - nutpie
+  - sympytensor
+  - pymc-extras
 
   # JAX, optional for now
   - jax
-  - blackjax
 #  - jaxlib=*=*cuda*
 
   # For building docs
@@ -55,7 +56,5 @@ dependencies:
   - pandas-datareader
 
   - pip:
-      - sympytensor
       - numdifftools
-      - git+https://github.com/pymc-devs/pymc-extras.git
       - -e ../.

--- a/conda_envs/environment_docs.yml
+++ b/conda_envs/environment_docs.yml
@@ -18,10 +18,11 @@ dependencies:
   - statsmodels
   - preliz
   - sympy<1.13
-#  - pymc-extras
+  - pymc-extras
   - better-optimize
   - jax
   - nutpie
+  - sympytensor
 
   # Extra dependencies for docs build
   - ipython
@@ -38,7 +39,3 @@ dependencies:
   - sphinxcontrib-bibtex
   - pydata-sphinx-theme
   - watermark
-
-  - pip:
-      - sympytensor
-      - git+https://github.com/pymc-devs/pymc-extras.git

--- a/conda_envs/geconpy_test.yml
+++ b/conda_envs/geconpy_test.yml
@@ -28,9 +28,9 @@ dependencies:
   - pip
   - better-optimize
   - nutpie
+  - sympytensor
+  - pymc-extras
 
   - pip:
-      - sympytensor
       - numdifftools
       - jax
-      - git+https://github.com/pymc-devs/pymc-extras.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "gEconpy"
 dynamic = ['version']
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.11"
 authors = [{name="Jesse Grabowski", email='jessegrabowski@gmail.com'}]
 description = "A package for solving, estimating, and analyzing DSGE models"
 readme = 'README.md'


### PR DESCRIPTION
We don't actually support 3.10, so this changes the pyproject.toml to reflect that.

Also updates the CLI workflow config to test on both 3.11 and 3.12

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--49.org.readthedocs.build/en/49/

<!-- readthedocs-preview gEconpy end -->