### PR TITLE
Mixed frequency example notebook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: check-ast
     -   id: check-case-conflict
     -   id: check-added-large-files
-        exclude: ^docs/source/examples/estimation/rbc_with_growth\.ipynb$
+        exclude: ^docs/source/examples/estimation/(rbc_with_growth|mixed_frequency_estimation)\.ipynb$
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.15.0

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -17,7 +17,11 @@ from pymc.pytensorf import rewrite_pregrad
 from pymc_extras.statespace.core.properties import Coord, Parameter, Shock, State, SymbolicVariable
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
 from pymc_extras.statespace.utils.constants import (
+    ALL_STATE_AUX_DIM,
+    ALL_STATE_DIM,
     JITTER_DEFAULT,
+    OBS_STATE_AUX_DIM,
+    OBS_STATE_DIM,
     SHOCK_AUX_DIM,
     SHOCK_DIM,
 )
@@ -1203,6 +1207,91 @@ class DSGEStateSpace(PyMCStateSpace):
                 "policy_resid_within_tol",
                 pt.switch(pt.lt(policy_resid, solver_tol), 0.0, -np.inf),
             )
+
+    def sample_autocorrelation_matrices(
+        self,
+        idata,
+        n_lags: int = 10,
+        observed: bool = False,
+        lag_step: int = 1,
+        compile_kwargs: dict | None = None,
+    ) -> xr.DataArray:
+        r"""
+        Posterior distribution of the model-implied autocorrelation matrices.
+
+        For each posterior draw the stationary state covariance :math:`\Sigma` is found from the discrete Lyapunov
+        equation :math:`\Sigma = T \Sigma T^\top + R Q R^\top`, and the autocorrelation at lag :math:`k` is
+        :math:`T^{k \cdot \texttt{lag\_step}} \Sigma`, normalized by the state standard deviations. The whole
+        calculation is built as a single PyTensor graph and evaluated across every draw at once with
+        :func:`pymc.compute_deterministics`, so there is no Python loop over samples.
+
+        The model must already have been built with :meth:`build_statespace_graph`, which the presence of ``idata``
+        implies.
+
+        Parameters
+        ----------
+        idata : arviz.InferenceData
+            Inference data whose ``posterior`` group holds draws of the model parameters.
+        n_lags : int
+            Number of non-zero lags to compute; the returned ``lag`` dimension has ``n_lags + 1`` entries. Default 10.
+        observed : bool
+            Return the autocorrelation of the *observed* series -- the design matrix applied to the state, with
+            measurement error included in the lag-0 variance -- instead of the latent states. Default False.
+        lag_step : int
+            Spacing between lags, in model periods. Use 1 for the model's native frequency. For an observable that is
+            a temporal aggregate (for example an annual series from a quarterly model), set this to the aggregation
+            period so successive lags are one observation apart. Default 1.
+        compile_kwargs : dict, optional
+            Passed through to :func:`pymc.compute_deterministics`.
+
+        Returns
+        -------
+        DataArray
+            Autocorrelation matrices with dimensions ``(chain, draw, lag, state, state_aux)``, where the state
+            dimensions are the observed states when ``observed`` is True and the latent states otherwise.
+        """
+        posterior = idata.posterior if hasattr(idata, "posterior") else idata
+        state_dim = OBS_STATE_DIM if observed else ALL_STATE_DIM
+        aux_dim = OBS_STATE_AUX_DIM if observed else ALL_STATE_AUX_DIM
+        name = "observation_autocorrelation" if observed else "autocorrelation"
+        coords = {**self.coords, "lag": np.arange(n_lags + 1)}
+
+        with pm.Model(coords=coords) as acf_model:
+            self._build_dummy_graph()
+            self._insert_random_variables()
+            _, _, _, _, T, Z, R, H, Q = self.unpack_statespace()
+
+            Sigma = pt.linalg.solve_discrete_lyapunov(T, R @ Q @ R.T)
+
+            # Advance ``lag_step`` model periods per lag, then accumulate T^(k * lag_step) for k = 0 .. n_lags.
+            T_step = T
+            for _ in range(lag_step - 1):
+                T_step = T_step @ T
+            eye = pt.eye(T.shape[0])
+            powers = pytensor.scan(
+                lambda prev, mat: prev @ mat,
+                outputs_info=eye,
+                non_sequences=[T_step],
+                n_steps=n_lags,
+                return_updates=False,
+            )
+            T_powers = pt.concatenate([eye[None], powers], axis=0)
+
+            if observed:
+                autocov = (Z @ (T_powers @ Sigma)) @ Z.T
+                autocov_0 = Z @ Sigma @ Z.T + H  # observed lag-0 variance includes measurement error
+            else:
+                autocov = T_powers @ Sigma
+                autocov_0 = Sigma
+            autocov = pt.set_subtensor(autocov[0], autocov_0)
+
+            std = pt.sqrt(pt.diag(autocov_0))
+            autocorr = autocov / pt.outer(std, std)[None]
+            pm.Deterministic(name, autocorr, dims=("lag", state_dim, aux_dim))
+
+        return pm.compute_deterministics(
+            posterior, var_names=[name], model=acf_model, compile_kwargs=compile_kwargs, progressbar=False
+        )[name]
 
     def to_pymc(self, exclude_priors: list[str] | None = None):
         if exclude_priors is None:

--- a/gEconpy/model/statespace.py
+++ b/gEconpy/model/statespace.py
@@ -191,7 +191,7 @@ class DSGEStateSpace(PyMCStateSpace):
 
     def _setup_policy_matrices(
         self, A: pt.TensorVariable, B: pt.TensorVariable, C: pt.TensorVariable, D: pt.TensorVariable
-    ) -> tuple[pt.TensorVariable, pt.TensorVariable]:
+    ) -> tuple[pt.TensorVariable, pt.TensorVariable, pt.TensorVariable]:
         if self._solver == "gensys":
             T, R, _success = gensys_pt(A, B, C, D, **self._solver_kwargs)
         elif self._solver == "cycle_reduction":
@@ -202,6 +202,11 @@ class DSGEStateSpace(PyMCStateSpace):
             T, R, n_steps = scan_cycle_reduction(A, B, C, D, mode=self._mode, **self._solver_kwargs)
             self._n_steps = n_steps
 
+        # Evaluate the policy-function residual in the solver's variable order. A, B, and C
+        # have columns in ``var_order``, and T shares that basis until it is remapped below;
+        # computing the residual after the remap would mix the two orderings and inflate it.
+        resid = pt.square(A + B @ T + C @ T @ T).sum()
+
         # T comes back in the *permuted* variable order on both axes; R on its rows.
         # Map back to the user's variable order so the Kalman filter sees user variables.
         if not np.array_equal(self.var_order, np.arange(len(self.var_order))):
@@ -209,7 +214,7 @@ class DSGEStateSpace(PyMCStateSpace):
             T = T[inv][:, inv]
             R = R[inv]
 
-        return T, R
+        return T, R, resid
 
     @property
     def lead_var_idx(self) -> np.ndarray:
@@ -759,8 +764,7 @@ class DSGEStateSpace(PyMCStateSpace):
         permuted_lead_var_idx = self.inv_var_order[self.lead_var_idx]
         self._bk_output = check_bk_condition_pt(A, B, C, D, lead_var_idx=permuted_lead_var_idx)
 
-        T, R = self._setup_policy_matrices(A, B, C, D)
-        resid = pt.square(A + B @ T + C @ T @ T).sum()
+        T, R, resid = self._setup_policy_matrices(A, B, C, D)
 
         T = rewrite_pregrad(T)
         R = rewrite_pregrad(R)

--- a/gEconpy/plotting.py
+++ b/gEconpy/plotting.py
@@ -1,5 +1,6 @@
 import warnings
 
+from collections.abc import Mapping
 from itertools import product
 from typing import Any, Literal, cast
 
@@ -1320,61 +1321,257 @@ def annotate_heatmap(
     return texts
 
 
+def _acf_hdi_bounds(series: xr.DataArray, prob: float) -> tuple[np.ndarray, np.ndarray]:
+    """Return per-lag (lower, upper) bounds of the ``prob`` highest-density interval of ``series``."""
+    hdi = azs.hdi(series, prob=prob)
+    ci_dim = next(dim for dim in hdi.dims if dim != "lag")
+    return hdi.isel({ci_dim: 0}).values, hdi.isel({ci_dim: 1}).values
+
+
+def _plot_acf_intervals(
+    axis: plt.Axes,
+    series: xr.DataArray,
+    lags: np.ndarray,
+    sample_dims: list[str],
+    ci_probs: tuple[float, float],
+    color: str = "tab:blue",
+    offset: float = 0.0,
+    mean_kwargs: dict | None = None,
+    inner_hdi_kwargs: dict | None = None,
+    outer_hdi_kwargs: dict | None = None,
+) -> None:
+    """Draw a forest-style autocorrelation on ``axis``: a posterior-mean point plus two nested HDI sticks per lag."""
+    inner_prob, outer_prob = sorted(ci_probs)
+    mean = series.mean(sample_dims).values
+    outer_lo, outer_hi = _acf_hdi_bounds(series, outer_prob)
+    inner_lo, inner_hi = _acf_hdi_bounds(series, inner_prob)
+
+    x = lags + offset
+    axis.vlines(x, outer_lo, outer_hi, **{"color": color, "lw": 1.0, **(outer_hdi_kwargs or {})})
+    axis.vlines(x, inner_lo, inner_hi, **{"color": color, "lw": 3.0, **(inner_hdi_kwargs or {})})
+    axis.scatter(x, mean, **{"color": color, "s": 38, "zorder": 3, **(mean_kwargs or {})})
+
+
+def _collect_acf_diagonals(models: dict, sample_dims: tuple[str, ...]):
+    """Diagonalize each model's autocorrelation tensor; return (diagonals, present-sample-dims, variable dim)."""
+    diagonals, present_by_model, var_dim = {}, {}, None
+    for label, tensor in models.items():
+        present = [dim for dim in sample_dims if dim in tensor.dims]
+        var_dims = [dim for dim in tensor.dims if dim != "lag" and dim not in present]
+        if len(var_dims) != 2:
+            raise ValueError(
+                "Expected an autocorrelation tensor with a 'lag' dimension and two variable dimensions, but found "
+                f"non-lag/sample dimensions {var_dims}."
+            )
+        diagonals[label] = xr_diagonal(tensor, dims=var_dims)
+        present_by_model[label] = present
+        var_dim = var_dims[0]
+    return diagonals, present_by_model, var_dim
+
+
+_REFERENCE_DEFAULTS = {"facecolors": "none", "edgecolors": "k", "s": 60, "linewidths": 1.6, "zorder": 4}
+
+
+def _draw_acf_panel(
+    axis,
+    variable,
+    diagonals,
+    present_by_model,
+    var_dim,
+    lags,
+    ci_probs,
+    offsets,
+    colors,
+    reference,
+    ref_var_dim,
+    mean_kwargs,
+    inner_hdi_kwargs,
+    outer_hdi_kwargs,
+    stem_kwargs,
+    reference_kwargs,
+):
+    """Draw one autocorrelation subplot: each model's forest (or stem) plus an optional hollow reference overlay."""
+    axis.axhline(0, color="k", lw=0.5)
+    for (label, model_diagonal), offset, color in zip(diagonals.items(), offsets, colors, strict=False):
+        if variable not in model_diagonal.coords[var_dim].values:
+            continue
+        series = model_diagonal.sel({var_dim: variable})
+        if present_by_model[label]:
+            _plot_acf_intervals(
+                axis,
+                series,
+                lags,
+                present_by_model[label],
+                ci_probs,
+                color=color,
+                offset=offset,
+                mean_kwargs=mean_kwargs,
+                inner_hdi_kwargs=inner_hdi_kwargs,
+                outer_hdi_kwargs=outer_hdi_kwargs,
+            )
+        else:
+            axis.scatter(lags + offset, series.values, **{"color": color, **(stem_kwargs or {})})
+            axis.vlines(lags + offset, 0, series.values, color=color)
+
+    if ref_var_dim is not None and variable in reference.coords[ref_var_dim].values:
+        ref_series = reference.sel({ref_var_dim: variable})
+        axis.scatter(
+            reference.coords["lag"].values, ref_series.values, **{**_REFERENCE_DEFAULTS, **(reference_kwargs or {})}
+        )
+
+    [spine.set_visible(False) for spine in axis.spines.values()]
+    axis.grid(ls="--", lw=0.5)
+    axis.set(title=str(variable))
+
+
+def _add_acf_legend(
+    fig: plt.Figure, model_labels: list, colors: list[str], has_reference: bool, reference_kwargs: dict | None = None
+) -> None:
+    """Add a legend distinguishing overlaid models and/or the reference series, if either is present."""
+    handles, labels = [], []
+    if len(model_labels) > 1:
+        handles += [Line2D([0], [0], color=color, lw=3) for color in colors]
+        labels += [str(label) for label in model_labels]
+    if has_reference:
+        ref = {**_REFERENCE_DEFAULTS, **(reference_kwargs or {})}
+        handles.append(
+            Line2D(
+                [0],
+                [0],
+                ls="none",
+                marker="o",
+                mfc=ref["facecolors"],
+                mec=ref["edgecolors"],
+                mew=ref["linewidths"],
+                ms=ref["s"] ** 0.5,
+            )
+        )
+        labels.append("data")
+    if handles and fig.axes:
+        fig.axes[0].legend(handles, labels, fontsize=8)
+
+
 def plot_acf(
-    acorr: np.ndarray | xr.DataArray,
+    acorr: xr.DataArray | Mapping[str, xr.DataArray],
     vars_to_plot: list[str] | None = None,
+    sample_dims: tuple[str, ...] = ("chain", "draw"),
+    ci_probs: tuple[float, float] = (0.5, 0.94),
+    reference: xr.DataArray | None = None,
+    dodge: float = 0.2,
     figsize: tuple[int, int] | None = (14, 4),
     dpi: int | None = 100,
     n_cols: int | None = 4,
+    mean_kwargs: dict | None = None,
+    inner_hdi_kwargs: dict | None = None,
+    outer_hdi_kwargs: dict | None = None,
+    stem_kwargs: dict | None = None,
+    reference_kwargs: dict | None = None,
 ) -> plt.Figure:
-    """
+    r"""
     Plot the autocorrelation function for a set of variables.
+
+    ``acorr`` is an autocorrelation tensor with a ``lag`` dimension and two square variable dimensions (the
+    cross-correlation axes, e.g. ``variable``/``variable_aux`` or ``state``/``state_aux``); only the diagonal —
+    each variable's own autocorrelation — is drawn. If the tensor also carries posterior sample dimensions
+    (``chain``, ``draw``), the result is an uncertainty-aware **forest**: a point at the posterior mean with two
+    nested credible-interval sticks at each lag. Otherwise it is a single-estimate **stem** plot.
+
+    Pass a mapping of ``{label: tensor}`` to overlay several models on the same axes; their forests are dodged
+    along the lag axis, coloured per model, and a legend of the labels is added.
 
     Parameters
     ----------
-    acorr_matrix: DataArray
-        Tensor of correlations.
-    vars_to_plot: list of str, optional
-        List of variables to plot. If not provided, all variables in `acorr_matrix` will be plotted.
-    figsize: tuple, optional
-        Figure size in inches.
-    dpi: int, optional
-        Figure resolution in dots per inch.
-    n_cols: int, optional
-        Number of columns in the subplot grid.
+    acorr : DataArray or mapping of str to DataArray
+        The autocorrelation tensor(s). A single tensor is plotted directly; a mapping overlays one dodged,
+        coloured forest per entry. Each tensor must have a ``lag`` dimension and exactly two non-lag, non-sample
+        variable dimensions, and may additionally carry the ``sample_dims``.
+    vars_to_plot : list of str, optional
+        Variables to plot. Plot every variable in ``acorr`` (the first entry, if a mapping) when not provided.
+    sample_dims : tuple of str, optional
+        Dimensions treated as posterior samples; their presence switches stems to forest intervals. Default
+        ``("chain", "draw")``.
+    ci_probs : tuple of float, optional
+        The two credible-interval probabilities drawn at each lag as (inner, outer); the inner interval gets the
+        thicker line. Ignored for tensors with no sample dimensions. Default ``(0.5, 0.94)``.
+    reference : DataArray, optional
+        A second autocorrelation to overlay as hollow markers — typically the empirical ACF of the observed data,
+        for a model-vs-data check. Indexed by ``lag`` and a single variable dimension; only variables that also
+        appear in ``acorr`` are overlaid. Default None.
+    dodge : float, optional
+        Horizontal offset between successive models' forests when ``acorr`` is a mapping. Default 0.2.
+    figsize : tuple, optional
+        Figure size in inches. Default ``(14, 4)``.
+    dpi : int, optional
+        Figure resolution in dots per inch. Default 100.
+    n_cols : int, optional
+        Number of columns in the subplot grid. Default 4.
+    mean_kwargs : dict, optional
+        Keyword arguments forwarded to ``Axes.scatter`` for the posterior-mean point of each forest, merged over
+        the defaults ``{"s": 38, "zorder": 3}`` (per-model ``color`` is set automatically). Default None.
+    inner_hdi_kwargs : dict, optional
+        Keyword arguments forwarded to ``Axes.vlines`` for the inner (thicker) HDI stick, merged over the default
+        ``{"lw": 3.0}``. Default None.
+    outer_hdi_kwargs : dict, optional
+        Keyword arguments forwarded to ``Axes.vlines`` for the outer (thinner) HDI stick, merged over the default
+        ``{"lw": 1.0}``. Default None.
+    stem_kwargs : dict, optional
+        Keyword arguments forwarded to ``Axes.scatter`` for the stem marker drawn when a tensor has no sample
+        dimensions. Default None.
+    reference_kwargs : dict, optional
+        Keyword arguments forwarded to ``Axes.scatter`` for the hollow reference markers, merged over the defaults
+        ``{"facecolors": "none", "edgecolors": "k", "s": 60, "linewidths": 1.6, "zorder": 4}``. The legend proxy
+        for the reference series is kept in sync with these settings. Default None.
 
     Returns
     -------
     matplotlib.figure.Figure
         Figure object containing the plots.
     """
-    all_variables = acorr.coords["variable"].values
+    models = {None: acorr} if isinstance(acorr, xr.DataArray) else dict(acorr)
+    diagonals, present_by_model, var_dim = _collect_acf_diagonals(models, sample_dims)
+
+    diagonal = diagonals[next(iter(diagonals))]
+    all_variables = diagonal.coords[var_dim].values
     if vars_to_plot is None:
         vars_to_plot = all_variables
-
     else:
-        for var in vars_to_plot:
-            if var not in all_variables:
-                raise ValueError(f"Can not plot variable {var}, it was not found in the provided covariance matrix")
+        missing = [var for var in vars_to_plot if var not in all_variables]
+        if missing:
+            raise ValueError(f"Cannot plot {missing}; not found in the provided autocorrelation tensor")
 
     n_plots = len(vars_to_plot)
     n_cols = min(n_cols, n_plots)
-
     fig = plt.figure(figsize=figsize, dpi=dpi, layout="constrained")
     gc, plot_locs = prepare_gridspec_figure(n_cols=n_cols, n_plots=n_plots, figure=fig)
+    lags = diagonal.coords["lag"].values
 
-    acorr_matrix = xr_diagonal(acorr, dims=["variable", "variable_aux"]).sel(variable=vars_to_plot)
-    x_values = acorr_matrix.coords["lag"]
+    n_models = len(models)
+    offsets = (np.arange(n_models) - (n_models - 1) / 2) * (dodge if n_models > 1 else 0.0)
+    colors = [f"C{i}" for i in range(n_models)]
+    ref_var_dim = next((dim for dim in reference.dims if dim != "lag"), None) if reference is not None else None
 
     for variable, plot_loc in zip(vars_to_plot, plot_locs, strict=False):
         axis = fig.add_subplot(gc[plot_loc])
-        axis.scatter(x_values, acorr_matrix.sel(variable=variable).values)
-        axis.vlines(x_values, 0, acorr_matrix.sel(variable=variable).values)
+        _draw_acf_panel(
+            axis,
+            variable,
+            diagonals,
+            present_by_model,
+            var_dim,
+            lags,
+            ci_probs,
+            offsets,
+            colors,
+            reference,
+            ref_var_dim,
+            mean_kwargs,
+            inner_hdi_kwargs,
+            outer_hdi_kwargs,
+            stem_kwargs,
+            reference_kwargs,
+        )
 
-        [spine.set_visible(False) for spine in axis.spines.values()]
-        axis.grid(ls="--", lw=0.5)
-        axis.set(title=variable)
-
+    _add_acf_legend(fig, list(models), colors, reference is not None, reference_kwargs)
     return fig
 
 

--- a/tests/model/test_statespace.py
+++ b/tests/model/test_statespace.py
@@ -1,14 +1,18 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import pymc as pm
 import pytensor
 import pytest
+import xarray as xr
 
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor.variable import TensorConstant
 
 from gEconpy import statespace_from_gcn
 from gEconpy.model.statespace import data_from_prior, prepare_mixed_frequency_data
+from gEconpy.model.statistics import autocorrelation_matrix
 from tests._resources.cache_compiled_models import (
     load_and_cache_model,
     load_and_cache_statespace,
@@ -1204,3 +1208,94 @@ def test_constant_params_baked_into_observation_equations():
     d = ss_mod.ssm["obs_intercept"]
     free_leaves = {a.name for a in ancestors([d]) if a.owner is None and a.name and not isinstance(a, TensorConstant)}
     assert "alpha" not in free_leaves
+
+
+@pytest.fixture(scope="module")
+def autocorrelation_setup():
+    """Build a mixed-frequency RBC state space and a small fake posterior over its parameters."""
+    ss_mod = statespace_from_gcn(TEST_GCNS / "rbc_linearized.gcn", verbose=False)
+    ss_mod.configure(
+        observed_states=["Y", "K"],
+        measurement_error=["Y", "K"],
+        temporal_aggregation={"Y": "sum"},
+        solver="gensys",
+        verbose=False,
+    )
+    with pm.Model():
+        ss_mod.to_pymc()
+        pm.Gamma("sigma_epsilon_A", alpha=2, beta=100)
+        pm.Gamma("error_sigma_Y", alpha=2, beta=100)
+        pm.Gamma("error_sigma_K", alpha=2, beta=100)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            ss_mod.build_statespace_graph(np.full((40, 2), np.nan), add_norm_check=False)
+
+    calib = load_and_cache_model("rbc_linearized.gcn").parameters()
+    rng = np.random.default_rng(0)
+    posterior = xr.Dataset(
+        {
+            name: (
+                ("chain", "draw"),
+                (float(calib[name]) if name in calib else 0.01) + 1e-4 * rng.standard_normal((2, 8)),
+            )
+            for name in ss_mod.param_names
+        },
+        coords={"chain": np.arange(2), "draw": np.arange(8)},
+    )
+    return ss_mod, posterior
+
+
+def test_sample_autocorrelation_matrices_shape_and_normalization(autocorrelation_setup):
+    ss_mod, posterior = autocorrelation_setup
+
+    latent = ss_mod.sample_autocorrelation_matrices(posterior, n_lags=6)
+    assert latent.dims == ("chain", "draw", "lag", "state", "state_aux")
+    assert latent.sizes["lag"] == 7
+    assert float(np.abs(latent).max()) <= 1.0 + 1e-6
+
+    # The lag-0 autocorrelation is exactly 1 on the diagonal.
+    diag0 = latent.isel(lag=0).mean(["chain", "draw"]).values
+    np.testing.assert_allclose(np.diag(diag0), 1.0, atol=1e-6)
+
+    observed = ss_mod.sample_autocorrelation_matrices(posterior, n_lags=6, observed=True, lag_step=4)
+    assert observed.dims == ("chain", "draw", "lag", "observed_state", "observed_state_aux")
+    obs_diag0 = observed.isel(lag=0).mean(["chain", "draw"]).values
+    np.testing.assert_allclose(np.diag(obs_diag0), 1.0, atol=1e-6)
+
+
+def test_sample_autocorrelation_lag_step_subsamples_lags(autocorrelation_setup):
+    ss_mod, posterior = autocorrelation_setup
+
+    # ACF at lag_step=2, lag k equals ACF at lag_step=1, lag 2k (both are T^(2k) @ Sigma).
+    step_1 = ss_mod.sample_autocorrelation_matrices(posterior, n_lags=8).mean(["chain", "draw"])
+    step_2 = ss_mod.sample_autocorrelation_matrices(posterior, n_lags=4, lag_step=2).mean(["chain", "draw"])
+    np.testing.assert_allclose(step_2.values, step_1.isel(lag=slice(None, None, 2)).values, atol=1e-5)
+
+
+def test_sample_autocorrelation_matches_analytical_acf(autocorrelation_setup):
+    """The sampled latent ACF reproduces the analytical ``autocorrelation_matrix`` at a single calibrated draw."""
+    ss_mod, _ = autocorrelation_setup
+    model = load_and_cache_model("rbc_linearized.gcn")
+    calib = model.parameters()
+
+    # A degenerate posterior (one draw at the calibrated values) makes the comparison exact.
+    degenerate = xr.Dataset(
+        {
+            name: (("chain", "draw"), np.full((1, 1), float(calib[name]) if name in calib else 0.01))
+            for name in ss_mod.param_names
+        },
+        coords={"chain": [0], "draw": [0]},
+    )
+
+    analytical = autocorrelation_matrix(
+        model, shock_cov_matrix=np.eye(1) * 0.01, correlation=True, return_xr=True, verbose=False
+    )
+    n_lags = analytical.sizes["lag"]
+    sampled = ss_mod.sample_autocorrelation_matrices(degenerate, n_lags=n_lags).isel(chain=0, draw=0)
+
+    for variable in analytical.coords["variable"].values:
+        np.testing.assert_allclose(
+            sampled.sel(state=variable, state_aux=variable).isel(lag=slice(0, n_lags)).values,
+            analytical.sel(variable=variable, variable_aux=variable).values,
+            atol=1e-4,
+        )

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -131,6 +131,34 @@ def acf_data(one_block_model):
 
 
 @pytest.fixture(scope="session")
+def posterior_acf():
+    """Synthetic posterior autocorrelation tensor (chain, draw, lag, variable, variable_aux)."""
+    rng = np.random.default_rng(0)
+    variables, n_lags = ["Y", "C", "K"], 6
+    values = np.zeros((4, 50, n_lags + 1, 3, 3))
+    for i in range(3):
+        rho = 0.8 + 0.05 * rng.standard_normal((4, 50, 1))
+        values[:, :, :, i, i] = rho ** np.arange(n_lags + 1)
+    return xr.DataArray(
+        values,
+        dims=["chain", "draw", "lag", "variable", "variable_aux"],
+        coords={"lag": np.arange(n_lags + 1), "variable": variables, "variable_aux": variables},
+    )
+
+
+@pytest.fixture(scope="session")
+def reference_acf():
+    """Synthetic point-estimate ACF (lag, variable) to overlay as a reference series."""
+    variables, n_lags = ["Y", "C", "K"], 6
+    values = np.stack([0.75 ** np.arange(n_lags + 1) for _ in variables], axis=1)
+    return xr.DataArray(
+        values,
+        dims=["lag", "variable"],
+        coords={"lag": np.arange(n_lags + 1), "variable": variables},
+    )
+
+
+@pytest.fixture(scope="session")
 def sensitivity_data(one_block_model):
     # eigenvalue_sensitivity forwards its own `verbose` into model.steady_state, so
     # `verbose` must not also appear in steady_state_kwargs.
@@ -500,8 +528,27 @@ def test_plot_acf_defaults_plots_all_variables(acf_data, one_block_model):
 
 
 def test_plot_acf_bad_var_raises(acf_data):
-    with pytest.raises(ValueError, match="Can not plot variable Invalid"):
+    with pytest.raises(ValueError, match="Cannot plot"):
         plot_acf(acf_data, vars_to_plot=["K", "C", "Invalid"])
+
+
+def test_plot_acf_forest_axis_count(posterior_acf):
+    # A tensor carrying chain/draw renders one panel per variable as a forest.
+    fig = plot_acf(posterior_acf)
+    assert len(fig.axes) == posterior_acf.sizes["variable"]
+
+
+def test_plot_acf_reference_adds_data_legend(posterior_acf, reference_acf):
+    fig = plot_acf(posterior_acf, reference=reference_acf)
+    legend_texts = [text.get_text() for text in fig.axes[0].get_legend().get_texts()]
+    assert "data" in legend_texts
+
+
+def test_plot_acf_multiple_models_legend_and_axes(posterior_acf):
+    fig = plot_acf({"levels": posterior_acf, "growth": posterior_acf}, vars_to_plot=["Y", "C"])
+    legend_texts = [text.get_text() for text in fig.axes[0].get_legend().get_texts()]
+    assert legend_texts == ["levels", "growth"]
+    assert len(fig.axes) == 2
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
- Fix bug where policy function residual was incorrectly computed
- Add statespace helpers to compute posterior ACF 
- Add new example notebook: Mixed-Frequency Estimation

<!-- readthedocs-preview gEconpy start -->
----
📚 Documentation preview 📚: https://gEconpy--101.org.readthedocs.build/en/101/

<!-- readthedocs-preview gEconpy end -->